### PR TITLE
Added support for 'getDecoration' callback

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -36,6 +36,7 @@ var fns = [
   saveAccessToken,
   generateRefreshToken,
   saveRefreshToken,
+  getResponseDecoration,
   sendResponse
 ];
 
@@ -449,6 +450,25 @@ function saveRefreshToken (done) {
 }
 
 /**
+ * Get the extra object to be returned in response
+ *
+ * @param  {Function} done
+ * @this   OAuth
+ */
+function getResponseDecoration (done) {
+  var self = this;
+  if (this.model.getDecoration) {
+    this.model.getDecoration(this.req, function (err, extra) {
+      if (err) return done(error('server_error', false, err));
+      if (extra) self.extra = extra;
+      done();
+    });
+  } else {
+    done();
+  }
+}
+
+/**
  * Create an access token and save it with the model
  *
  * @param  {Function} done
@@ -459,6 +479,10 @@ function sendResponse (done) {
     token_type: 'bearer',
     access_token: this.accessToken
   };
+
+  if (this.extra) {
+    response.extra = this.extra;
+  }
 
   if (this.config.accessTokenLifetime !== null) {
     response.expires_in = this.config.accessTokenLifetime;


### PR DESCRIPTION
In some cases, one will like to sends extra information as apart of the response body. One
such case is auth resquests over weak\expensive connections, where one wants to get some
basic user information as part of response, instead of making a second call.
